### PR TITLE
Show ISF-value on overview tab

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -696,6 +696,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'reservoir' : reservoir_data // The expected reservoir volume at which to deliver the microbolus (the reservoir volume from right before the last pumphistory run)
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
         , 'sensitivityRatio' : sensitivityRatio // autosens ratio (fraction of normal basal)
+        , 'variable_sens' : sens
     };
 
     // generate predicted future BGs based on IOB, COB, and current absorption rate


### PR DESCRIPTION
Mit dieser zusätzlichen Zeile wird (so wie von Milos für dynISF eingefügt) die ISF-Änderung im Overview Tab angezeigt. Unter dem autosens-Wert erscheint eine Zeile mit dem Vergleich Profil-ISF -> ISF (=sens), also z. B. 46 -> 38.
Ich finde diese Information sehr hilfreich, um auf einen Blick zu verstehen, was dynISF gerade tut. Erscheint der Wert überraschend, durchsuche ich script debug. Bei mir ist sie jedenfalls aktiv und funktioniert, für mich persönlich eine sehr wichtige Information. Nur so als Vorschlag.